### PR TITLE
IRGen Framework

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,13 @@ members = [
     "src/lexer",
     "src/parser",
     "src/ast",
-    "src/analyser"
+    "src/analyser",
+    "src/irgen"
 ]
 
 [dependencies]
 clap = "4.5.22"
 colored = "2.1.0"
-llvm-ir = { version = "0.11.1", features = ["llvm-17"] }
 spl_parser = { path = "src/parser" }
 spl_analyser = { path = "src/analyser" }
+spl_irgen = { path = "src/irgen" }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ C-like Compiler in Rust
 ```
 .
 ├── Cargo.toml # Add your sub-project in the [workspace] members field.
-├── Dockerfile
+├── Dockerfile # Build the environment for the project
 ├── docs
 │   ├── cs323-project-tutorial1.pdf
 │   ├── cs323-project-tutorial2.pdf
@@ -43,6 +43,9 @@ C-like Compiler in Rust
 │   ├── ast
 │   │   ├── Cargo.toml # Define your dependencies in the sub-project
 │   │   └── src # In lib.rs please pub mod all the crates.
+│   ├── irgen
+│   │   ├── Cargo.toml
+│   │   └── src
 │   ├── lexer
 │   │   ├── Cargo.lock
 │   │   ├── Cargo.toml
@@ -56,7 +59,8 @@ C-like Compiler in Rust
 │       ├── phase1
 │       ├── phase2
 │       ├── phase3
-│       ├── test_0_r00.out
+│       ├── test_0_r00.out # Minimal testcase
+│       ├── test_0_r00.ll # LLVM IR of the minimal testcase
 │       └── test_0_r00.spl
 └── target
     ├── CACHEDIR.TAG

--- a/src/analyser/src/lib.rs
+++ b/src/analyser/src/lib.rs
@@ -22,7 +22,7 @@ mod tests {
             .expect("Unable to read file");
         let expected = out_content.trim();
 
-        let mut walker = Walker::new(file_path);
+        let mut walker = Walker::new(file_path, true);
 
         walker.traverse();
         let _table = walker.get_tables();

--- a/src/irgen/Cargo.toml
+++ b/src/irgen/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "spl_irgen"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+inkwell = { version = "0.5.0", features = ["llvm17-0"] }

--- a/src/irgen/src/emit.rs
+++ b/src/irgen/src/emit.rs
@@ -1,0 +1,2 @@
+extern crate inkwell as llvm;
+

--- a/src/irgen/src/lib.rs
+++ b/src/irgen/src/lib.rs
@@ -1,4 +1,5 @@
-
+mod checker;
+mod emit;
 
 #[cfg(test)]
 mod tests {

--- a/src/irgen/src/lib.rs
+++ b/src/irgen/src/lib.rs
@@ -1,0 +1,10 @@
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gen_test_r00() {
+    }
+}

--- a/src/lexer/src/lib.rs
+++ b/src/lexer/src/lib.rs
@@ -278,6 +278,7 @@ mod test {
                 (RightBrace, "}"),
                 (RightBrace, "}"),
                 (KeywordReturn, "return"),
+                (Identifier(String::from("a")), "a"),
                 (Semicolon, ";"),
                 (RightBrace, "}"),
             ][..]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,7 @@
-extern crate llvm_ir as llvm;
-
 use spl_parser::{parse_from_file};
 use spl_analyser::walker::Walker;
 use clap::{Arg, Command};
 use colored::Colorize;
-// use std::ffi::CString;
-// use std::ptr;
 
 fn main() {
     let args = Command::new("Incredibuild")
@@ -34,37 +30,4 @@ fn main() {
     for error in errors {
         println!("{}", error.to_string().red());
     }
-
-    // unsafe {
-    //     codegen(parsed_input);
-    // }
 }
-
-// unsafe fn codegen(input: String) {
-//     let context = llvm::core::LLVMContextCreate();
-//     let module = llvm::core::LLVMModuleCreateWithName(b"example_module\0".as_ptr() as *const _);
-//     let builder = llvm::core::LLVMCreateBuilderInContext(context);
-
-//     // In LLVM, you get your types from functions.
-//     let int_type = llvm::core::LLVMInt64TypeInContext(context);
-//     let function_type = llvm::core::LLVMFunctionType(int_type, ptr::null_mut(), 0, 0);
-//     let function = llvm::core::LLVMAddFunction(module, b"main\0".as_ptr() as *const _, function_type);
-
-//     let entry_name = CString::new("entry").unwrap();
-//     let bb = llvm::core::LLVMAppendBasicBlockInContext(context, function, entry_name.as_ptr());
-//     llvm::core::LLVMPositionBuilderAtEnd(builder, bb);
-
-//     // The juicy part: construct a `LLVMValue` from a Rust value:
-//     let int_value: u64 = input.parse().unwrap();
-//     let int_value = llvm::core::LLVMConstInt(int_type, int_value, 0);
-
-//     llvm::core::LLVMBuildRet(builder, int_value);
-
-//     // Instead of dumping to stdout, let's write out the IR to `out.ll`
-//     let out_file = CString::new("out.ll").unwrap();
-//     llvm::core::LLVMPrintModuleToFile(module, out_file.as_ptr(), ptr::null_mut());
-
-//     llvm::core::LLVMDisposeBuilder(builder);
-//     llvm::core::LLVMDisposeModule(module);
-//     llvm::core::LLVMContextDispose(context);
-// }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,14 @@
 use spl_parser::{parse_from_file};
 use spl_analyser::walker::Walker;
-use clap::{Arg, Command};
+use clap::{Arg, Command, ArgAction};
 use colored::Colorize;
 
-fn main() {
+fn main() -> Result<(), String> {
     let args = Command::new("Incredibuild")
         .about("Compile SPL code to executable")
-        .arg(
-            Arg::new("input").index(1).required(true)
-        )
-        .arg(
-            Arg::new("output").short('o').long("output").required(false)
-        )
+        .arg(Arg::new("input").index(1).required(true))
+        .arg(Arg::new("output").short('o').long("output").required(false))
+        .arg(Arg::new("debug").short('d').long("debug").required(false).action(ArgAction::SetTrue))
         .get_matches();
 
     let source_path = args.get_one::<String>("input").unwrap();
@@ -21,13 +18,19 @@ fn main() {
         Ok(_) => println!("{}", "Parsed successfully".green()),
         Err(e) => {
             println!("{}", e.red());
+            return Err("Error in parsing".to_string());
         }
     }
 
-    let mut walker = Walker::new(&source_path);
+    let mut walker = Walker::new(&source_path, args.get_flag("debug"));
     walker.traverse();
     let errors = walker.get_errors();
     for error in errors {
         println!("{}", error.to_string().red());
     }
+    if errors.len() > 0 {
+        return Err("Error in analysis".to_string());
+    }
+
+    Ok(())
 }

--- a/src/parser/src/grammar.lalrpop
+++ b/src/parser/src/grammar.lalrpop
@@ -330,24 +330,11 @@ pub FuncDec: Box<tree::Function> = {
 }
 
 FuncCall: tree::Expr = {
-    <vl:@L> <name:Identifier> "(" ")" ";" <vr:@R> => {
+    <vl:@L> <name:Identifier> "(" <args:ArgList?> ")" ";" <vr:@R>=> {
         tree::Expr::FuncCall(
             tree::Function::FuncReference(
                 Box::new(name),
-                Vec::new()
-            ),
-            Span {
-                source: source.to_string(),
-                start: vl,
-                end: vr
-            }
-        )
-    },
-    <vl:@L> <name:Identifier> "(" <args:ArgList> ")" ";" <vr:@R>=> {
-        tree::Expr::FuncCall(
-            tree::Function::FuncReference(
-                Box::new(name),
-                args
+                args.unwrap_or(Vec::new())
             ),
             Span {
                 source: source.to_string(),
@@ -1197,9 +1184,7 @@ Specifier: tree::Value = {
     <t:"typechar"> => tree::Value::Char(' '),
     <t:"typestr"> => tree::Value::String(String::new()),
     <t:"void"> => tree::Value::Null,
-    "struct" <str: Identifier> => {
-        tree::Value::Struct(str)
-    },
+    "struct" <str: Identifier> => tree::Value::Struct(str)
 }
 
 Term: Box<tree::CompExpr> = {
@@ -1233,38 +1218,17 @@ Term: Box<tree::CompExpr> = {
     "+"? <n: "float"> => Box::new(tree::CompExpr::Value(tree::Value::Float(n))),
     "-"  <n: "float"> => Box::new(tree::CompExpr::Value(tree::Value::Float(-n))),
     <n: "char"> => Box::new(tree::CompExpr::Value(tree::Value::Char(n))),
-
-    <vl:@L> <ident: Identifier> "(" ")" <vr:@R>=> {
+    <vl:@L> <ident: Identifier> "(" <args:ArgList?> ")" <vr:@R>=> {
         Box::new(tree::CompExpr::FuncCall(
-            tree::Function::FuncReference(Box::new(ident), Vec::new())
+            tree::Function::FuncReference(Box::new(ident), args.unwrap_or(Vec::new()))
         ))
     },
-    <vl:@L> <ident: Identifier> "(" <args:ArgList> ")" <vr:@R>=> {
-        Box::new(tree::CompExpr::FuncCall(
-            tree::Function::FuncReference(Box::new(ident), args)
-        ))
-    },
-
     <s:StructRef> => {
         Box::new(tree::CompExpr::Variable(tree::Variable::StructReference(Box::new(s))))
     },
 
     // error recovery
-    <ident: Identifier> "(" <l:@L> <missing:!> <r:@R> => {
-        let error = ErrorRecovery {
-            error: ParseError::User {
-                error: LexicalError::MissingLexeme(Span {
-                    source: source.to_string(),
-                    start: l,
-                    end: l + 1
-                }, "closing parenthesis ')'".to_string())
-            },
-            dropped_tokens: Vec::new(),
-        };
-        errors.push(error);
-        Box::new(tree::CompExpr::MissingRP)
-    },
-    <ident: Identifier> "(" <args:ArgList> <l:@L> <missing:!> <r:@R> => {
+    <ident: Identifier> "(" ArgList? <l:@L> <missing:!> <r:@R> => {
         let error = ErrorRecovery {
             error: ParseError::User {
                 error: LexicalError::MissingLexeme(Span {

--- a/src/test/test_0_r00.ll
+++ b/src/test/test_0_r00.ll
@@ -1,0 +1,27 @@
+source_filename = "test_0_r00.spl"
+
+define i32 @main() #0 {
+  %1 = alloca i32, align 4
+  %2 = alloca i32, align 4
+  store i32 0, ptr %1, align 4
+  store i32 3, ptr %2, align 4
+  br label %3
+
+3:                                                ; preds = %0, %9
+  %4 = load i32, ptr %2, align 4
+  %5 = add nsw i32 %4, 1
+  store i32 %5, ptr %2, align 4
+  %6 = load i32, ptr %2, align 4
+  %7 = icmp eq i32 %6, 5
+  br i1 %7, label %8, label %9
+
+8:                                                ; preds = %3
+  br label %10
+
+9:                                                ; preds = %3
+  br label %3
+
+10:                                               ; preds = %8
+  %11 = load i32, ptr %2, align 4
+  ret i32 %11
+}

--- a/src/test/test_0_r00.out
+++ b/src/test/test_0_r00.out
@@ -1,2 +1,2 @@
 Function: main:[Body: [Variable Declaration: a = [0: u32] with dimensions []; Variable Assignment: a = 3: u32, While Loop (Condition: true):
-do Body: [Variable Assignment: a = (a + 1: u32), If: Condition: a == 5: u32 then Body: [Break]], Return: null]]
+do Body: [Variable Assignment: a = (a + 1: u32), If: Condition: a == 5: u32 then Body: [Break]], Return: a]]

--- a/src/test/test_0_r00.spl
+++ b/src/test/test_0_r00.spl
@@ -6,5 +6,5 @@ int main(){
             break;
         }
     }
-    return;
+    return a;
 }


### PR DESCRIPTION
This adds the initial files of LLVM IR generation feature with `inkwell` as the safe `llvm-sys` binding.

We needs to implement a lifetime checker in this stage. Further discussion would be required. See Notion docs for more details.

Also, I put a `verbose` flag to `Walker`'s outputs to hide from user's perspective, which can be enabled by adding a `-d` option in command.