### PR TITLE
IRGen updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,34 @@ SPL(SUSTech Programming Language) Compiler in Rust
 - [ ] Advanced
     - [ ] Lifetime Analysis
 
+## Getting Started
+
+At first, you need to setup the environment by installing Rust and Cargo, please follow instruction in [development](#development) section.
+
+Then you can build the project by running
+
+```bash
+cargo run /path/to/your/spl/file
+```
+
+> [!INFO]
+> Some of the functionalities are weird in release mode.
+
+See `cargo run` for more options.
+
 ## File structure
 
 ```
 .
-├── Cargo.toml # Add your sub-project in the [workspace] members field.
+├── Cargo.toml # Binding of submodules
 ├── Dockerfile # Build the environment for the project
 ├── docs
 │   ├── cs323-project-tutorial1.pdf
 │   ├── cs323-project-tutorial2.pdf
 │   ├── cs323-project-tutorial3.pdf
+│   ├── cs323-project-tutorial4.pdf
 │   ├── midterm-project-check.pdf
+│   ├── slides # Presentation slides
 │   ├── syntax.txt
 │   └── token.txt
 ├── LICENSE
@@ -47,7 +64,6 @@ SPL(SUSTech Programming Language) Compiler in Rust
 │   │   ├── Cargo.toml
 │   │   └── src
 │   ├── lexer
-│   │   ├── Cargo.lock
 │   │   ├── Cargo.toml
 │   │   └── src
 │   ├── main.rs
@@ -65,14 +81,6 @@ SPL(SUSTech Programming Language) Compiler in Rust
     └── test_0_r00.out # Sample output
 ```
 
-## Testing
-
-You can run according test to separate sub-project by using `cargo test` in the root of each sub-project.
-
-```bash
-cd src/lexer
-cargo test
-```
 
 ## Development
 
@@ -98,13 +106,22 @@ cargo run
 
 ### "Bare Metal" Mac
 
-Make sure you have Rust and Cargo installed. Install LLVM environment by
+If you're using Mac, make sure you have Rust and Cargo installed. Install LLVM environment by
 
 ```bash
 brew install llvm # or use the package manager you prefer
 
 # find where llvm is installed, for example
 export LLVM_SYS_170_PREFIX=/opt/homebrew/Cellar/llvm/19.1.2 # pretend to be LLVM@17 :)
+```
+
+### Testing
+
+You can run according test to separate crates by using `cargo test` in the root of each. For example
+
+```bash
+cd src/lexer
+cargo test
 ```
 
 ## Issue

--- a/src/irgen/src/lib.rs
+++ b/src/irgen/src/lib.rs
@@ -11,7 +11,7 @@ mod tests {
 
     #[test]
     fn test_compexpr() {
-        let source = "int main() { return 1 + 2 * 3;} ";
+        let source = "int main() { return 1 + 2 * 3; } ";
         let ast = spl_parser::parse(source).unwrap();
         let ir = emit_llvmir("test_compexpr", ast);
         assert_eq!(ir, "; ModuleID = 'test_compexpr'\nsource_filename = \"test_compexpr\"\n\ndefine i32 @main() {\nentry:\n  ret i32 7\n}\n");

--- a/src/parser/src/grammar.lalrpop
+++ b/src/parser/src/grammar.lalrpop
@@ -57,6 +57,8 @@ ArgList: Vec<Box<tree::CompExpr>> = {
         v.push(e);
         v
     },
+
+    // Error handling
     ArgList "," <l:@L> <missing:!> <r:@R> => {
         let error = ErrorRecovery {
             error: ParseError::User {
@@ -74,6 +76,13 @@ ArgList: Vec<Box<tree::CompExpr>> = {
 }
 
 VarDecs: Vec<tree::Variable> = {
+    <l:@L> <mut v:VarDecs> "," <e:VarDec> <r:@R> => {
+        v.push(e);
+        v
+    },
+    <e:VarDec> => vec![e],
+
+    // Error handling
     VarDecs "," <l:@L> ! <r:@R> => {
         let error = ErrorRecovery {
             error: ParseError::User {
@@ -87,15 +96,10 @@ VarDecs: Vec<tree::Variable> = {
         errors.push(error);
         Vec::new()
     },
-    <l:@L> <mut v:VarDecs> "," <e:VarDec> <r:@R> => {
-        v.push(e);
-        v
-    },
-    <e:VarDec> => vec![e],
 }
 
 ParaDec: tree::Variable = {
-    <l:@L> <missing:!> <name:Identifier?> <r:@R> => {
+    <l:@L> <missing:!> Identifier? <r:@R> => {
         let error = ErrorRecovery {
             error: ParseError::User {
                 error: LexicalError::MissingLexeme(Span {
@@ -135,6 +139,19 @@ ParaDec: tree::Variable = {
 }
 
 DimDecs: Vec<tree::CompExpr> = {
+    "[" <n:CompExpr> "]" => {
+        let mut v = Vec::new();
+        v.push(*n);
+        v
+    },
+    "[" <n:CompExpr> "]" <size:DimDecs> => {
+        let mut v = Vec::new();
+        v.push(*n);
+        v.extend(size);
+        v
+    },
+
+    // Error handling
     "[" CompExpr <l:@L> <missing:!> <r:@R> => {
         let error = ErrorRecovery {
             error: ParseError::User {
@@ -149,17 +166,6 @@ DimDecs: Vec<tree::CompExpr> = {
         errors.push(error);
         Vec::new()
     },
-    "[" <n:CompExpr> "]" => {
-        let mut v = Vec::new();
-        v.push(*n);
-        v
-    },
-    "[" <n:CompExpr> "]" <size:DimDecs> => {
-        let mut v = Vec::new();
-        v.push(*n);
-        v.extend(size);
-        v
-    }
 }
 
 /*
@@ -292,7 +298,6 @@ FieldsDec: Vec<tree::Variable> = {
 */
 pub FuncDec: Box<tree::Function> = {
     <ret: Specifier> <name:Identifier> <lb:"("> <params:ParaDecs> <l:@L> <rb:")"?> <r:@R> "{" <body:Body> "}" => {
-
         if rb == None {
             let error = ErrorRecovery {
                 error: ParseError::User {
@@ -302,16 +307,18 @@ pub FuncDec: Box<tree::Function> = {
                         end: r + 1
                     }, "closing parenthesis ')'".to_string())
                 },
-                dropped_tokens: Vec::new(), // or specify the dropped tokens
+                dropped_tokens: Vec::new(),
             };
             errors.push(error);
+            Box::new(tree::Function::Error)
+        } else {
+            Box::new(tree::Function::FuncDeclaration(
+                Box::new(name),
+                params,
+                Box::new(ret),
+                body
+            ))
         }
-        Box::new(tree::Function::FuncDeclaration(
-            Box::new(name),
-            params,
-            Box::new(ret),
-            body
-        ))
     },
     <ret: Specifier> <name:Identifier> <lb:"("> <params:ParaDecs> <l:@L> <rb:")"?> <r:@R> "{" <body:Body> ! <vr:@R> => {
         let error = ErrorRecovery {
@@ -322,11 +329,25 @@ pub FuncDec: Box<tree::Function> = {
                     end: vr + 1
                 }, "closing brace '}'".to_string())
             },
-            dropped_tokens: Vec::new(), // or specify the dropped tokens
+            dropped_tokens: Vec::new(),
         };
         errors.push(error);
         Box::new(tree::Function::Error)
-    }
+    },
+    <ret: Specifier> <name:Identifier> <lb:"("> <params:ParaDecs> <l:@L> <rb:")"?> <r:@R> "{" <body:Body> <vl:@L> ! <vr:@R> "{" Expr+ "}" "}" => {
+        let error = ErrorRecovery {
+            error: ParseError::User {
+                error: LexicalError::StatementError(Span {
+                    source: source.to_string(),
+                    start: vl,
+                    end: vr + 1
+                }, "No 'if' before 'else'".to_string())
+            },
+            dropped_tokens: Vec::new(),
+        };
+        errors.push(error);
+        Box::new(tree::Function::Error)
+    },
 }
 
 FuncCall: tree::Expr = {
@@ -957,6 +978,20 @@ VarDec: tree::Variable = {
     },
 
     // Error handling
+    <l:@L> "=" <r:@R> CompExpr => {
+        let error = ErrorRecovery {
+            error: ParseError::User {
+                error: LexicalError::MissingLexeme(Span {
+                    source: source.to_string(),
+                    start: l,
+                    end: l + 1
+                }, "left value".to_string())
+            },
+            dropped_tokens: Vec::new(),
+        };
+        errors.push(error);
+        tree::Variable::Error
+    },
     <ident: Identifier> <size: DimDecs?> "=" <l:@L> <missing:!> <r:@R> => {
         let error = ErrorRecovery {
             error: ParseError::User {
@@ -1040,7 +1075,7 @@ pub CompExpr: Box<tree::CompExpr> = {
     Term,
 
     #[precedence(level="2")] #[assoc(side="left")]
-    <lhs: CompExpr> <l:@L> <error: "error"> <r:@R> <rhs:CompExpr> => {
+    CompExpr <l:@L> <error: "error"> <r:@R> CompExpr => {
         let error = ErrorRecovery {
             error: ParseError::User {
                 error: LexicalError::UnknownLexeme(Span {
@@ -1055,7 +1090,7 @@ pub CompExpr: Box<tree::CompExpr> = {
         Box::new(tree::CompExpr::Error)
     },
 
-    <lhs:CompExpr> "^" <l:@L> <rhs:!> <r:@R> => {
+    CompExpr "^" <l:@L> ! <r:@R> => {
         let error = ErrorRecovery {
             error: ParseError::User {
                 error: LexicalError::MissingLexeme(Span {
@@ -1075,7 +1110,7 @@ pub CompExpr: Box<tree::CompExpr> = {
         ))
     },
 
-    <lhs:CompExpr> "%" <l:@L> <rhs:!> <r:@R> => {
+    CompExpr "%" <l:@L> ! <r:@R> => {
         let error = ErrorRecovery {
             error: ParseError::User {
                 error: LexicalError::MissingLexeme(Span {
@@ -1288,7 +1323,6 @@ extern {
 
     enum Token {
         "identifier" => Token::Identifier(<String>),
-    
         "int" => Token::LiteralInt(<u32>),
         "float" => Token::LiteralFloat(<f32>),
         "bool" => Token::LiteralBool(<bool>),
@@ -1300,7 +1334,6 @@ extern {
         "typestr" => Token::TypeString,
         "void" => Token::TypeVoid,
         "null" => Token::TypeNull,
-
         "(" => Token::LeftParen,
         ")" => Token::RightParen,
         "{" => Token::LeftBrace,
@@ -1311,7 +1344,6 @@ extern {
         "," => Token::Comma,
         ";" => Token::Semicolon,
         ":" => Token::Colon,
-
         "+" => Token::OpPlus,
         "-" => Token::OpMinus,
         "*" => Token::OpMul,
@@ -1330,7 +1362,6 @@ extern {
         "=" => Token::OpAssign,
         "++" => Token::OpIncrement,
         "--" => Token::OpDecrement,
-
         "if" => Token::KeywordIf,
         "else" => Token::KeywordElse,
         "while" => Token::KeywordWhile,
@@ -1338,11 +1369,9 @@ extern {
         "return" => Token::KeywordReturn,
         "break" => Token::KeywordBreak,
         "continue" => Token::KeywordContinue,
-
         "enum" => Token::DeclarationEnum,
         "struct" => Token::DeclarationStruct,
         "include" => Token::DeclarationInclude,
-
         "invalid" => Token::Invalid,
         "error" => Token::Error,
     }

--- a/src/parser/src/lib.rs
+++ b/src/parser/src/lib.rs
@@ -237,7 +237,6 @@ mod tests {
             );
         }
         for i in 1..14 {
-            if i == 7 || i == 8 { continue; } // skip "no-if-before-else" and "invalid statement"
             assert_parse_from_file(Parser::ProgramParser,
                 &format!("../../test/phase1/extra/test_1_s{:0>2}.spl", i),
                 &format!("../../test/phase1/extra/test_1_s{:0>2}.out", i)

--- a/test/phase1/extra/test_1_s07.out
+++ b/test/phase1/extra/test_1_s07.out
@@ -1,4 +1,4 @@
 Error type B at Line 5: Missing closing bracket ']'
 Error type B at Line 6: Missing right value
 Error type B at Line 7: Missing closing bracket ']'
-Error type B at Line 8: Unexpected statement
+Error type B at Line 8: Missing left value


### PR DESCRIPTION
## Changelog
- Add `printf` binding (295d29b)
- Parser now supports handling `no-if-before-else` and `missing-left-value` error (60df4ec)
- Fix some grammar mistakes in README (56c7acd)

`clang` supports directly call libc functions, so we can add some internal support for these functions, but analyzer should ignore them.